### PR TITLE
Fix timestamp interpolation in created file name

### DIFF
--- a/builder/vmware/vmx/config.go
+++ b/builder/vmware/vmx/config.go
@@ -51,7 +51,8 @@ func NewConfig(raws ...interface{}) (*Config, []string, error) {
 
 	// Defaults
 	if c.VMName == "" {
-		c.VMName = fmt.Sprintf("packer-%s-{{timestamp}}", c.PackerBuildName)
+		c.VMName = fmt.Sprintf(
+			"packer-%s-%d", c.PackerBuildName, interpolate.InitTime.Unix())
 	}
 
 	// Prepare the errors


### PR DESCRIPTION
This commit attempts to fix the timestamp-related part of #4885 by using the logic found in the analogous virtualbox implementation. In essence, it applies the solution from commit 93bb0d8 to the vmx case.

Closes part of #4885
